### PR TITLE
ADr for usagePlans

### DIFF
--- a/documenation/ADR/01.Usage_Plans.md
+++ b/documenation/ADR/01.Usage_Plans.md
@@ -1,0 +1,19 @@
+# Storing Usage Plan IDs in Secret Manager
+
+## Context
+
+Users need to be attached to different usage plans based on their payment plans/subscriptions. To implement this, I needed a deployment strategy that would allow me to create a REST API with API Gateway, create the usage plans, and then pass the usage plan IDs to the relevant Lambda functions as environment variables.
+
+## Problem
+
+However, I encountered a circular dependency issue between the Lambda functions, API Gateway, and the usage plans. Specifically:
+
+1. The REST API needs to be created first.
+2. The usage plans need to be created and attached to the API's stage.
+3. The Lambda functions need the usage plan IDs to be passed to them as environment variables.
+
+I even tried adding node dependencies between the resources, but it didn't resolve the issue. You would expect AWS CDK to deploy resources in the order they are defined in the code (synchronously), but apparently it does not work that way. (which sucks). It seems that the usagePlans & the lambda functions are deployed in parallel, which is why i got the circular dependency error.
+
+## Solution
+
+To solve this issue, I used Secret Manager to store the usage plans. This approach allows the Lambda functions to access the usage plans directly from Secret Manager, eliminating the circular dependency issue. By storing the usage plans in Secret Manager, i've decoupled the Lambdas from the usage plans


### PR DESCRIPTION
This adds the ADR describing the reason why we needed to store UsagePlanIds in secret manager